### PR TITLE
Fix: Resolve backend Docker build and runtime errors

### DIFF
--- a/DockerEntrypoint.sh
+++ b/DockerEntrypoint.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 
 # Start fail2ban
-[ $XUI_ENABLE_FAIL2BAN == "true" ] && fail2ban-client -x start
+if [ "$XUI_ENABLE_FAIL2BAN" = "true" ]; then
+  if command -v fail2ban-client >/dev/null 2>&1; then
+    fail2ban-client -x start
+  else
+    echo "Warning: fail2ban-client not found, but XUI_ENABLE_FAIL2BAN is true."
+  fi
+fi
 
 # Run x-ui
 exec /app/x-ui

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -5,6 +5,7 @@ WORKDIR /app
 
 # Copy go.mod and go.sum and download dependencies
 COPY go.mod go.sum ./
+RUN apk add --no-cache gcc musl-dev sqlite-dev
 RUN go mod download
 
 # Copy the rest of the application source code
@@ -15,7 +16,7 @@ COPY . .
 # The original entrypoint seems to be related to x-ui.sh or DockerEntrypoint.sh
 # We need to ensure the binary is built correctly.
 # For 3x-ui, the main.go seems to be the entry point.
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o /app/x-ui main.go
+RUN CGO_ENABLED=1 GOOS=linux go build -a -installsuffix cgo -o /app/x-ui main.go
 
 # Stage 2: Production environment
 FROM alpine:latest
@@ -33,6 +34,7 @@ COPY --from=builder /app/config/version /app/config/version
 # Ensure necessary directories exist and have correct permissions if needed by the app
 # The original compose file mounts $PWD/db/:/etc/x-ui/ and $PWD/cert/:/root/cert/
 # So, these paths should be available or created by the entrypoint script.
+RUN apk add --no-cache sqlite fail2ban
 RUN mkdir -p /etc/x-ui && \
     mkdir -p /root/cert && \
     chmod +x /app/x-ui.sh /app/DockerEntrypoint.sh /app/x-ui


### PR DESCRIPTION
This commit addresses two primary issues in the backend Docker setup:

1.  **Database Initialization Error (CGO_ENABLED):** The Go binary was previously compiled with `CGO_ENABLED=0`. This caused an error ("Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work") because `go-sqlite3` requires CGo.
    - Modified `Dockerfile.backend` to set `CGO_ENABLED=1` during the build.
    - Added `gcc`, `musl-dev`, and `sqlite-dev` to the builder stage dependencies for CGo compilation on Alpine.
    - Added `sqlite` to the final image stage for runtime library availability.

2.  **fail2ban-client Not Found Error:** The `DockerEntrypoint.sh` script attempted to start `fail2ban-client` without ensuring its presence in the image.
    - Added `fail2ban` to the `apk add` command in the final stage of `Dockerfile.backend`.
    - Updated `DockerEntrypoint.sh` to check if `fail2ban-client` is available before attempting to start it, preventing errors if it's not found (e.g., if `XUI_ENABLE_FAIL2BAN` is true but installation failed).

These changes should allow the backend container to build and start correctly, resolving the reported database and fail2ban errors. You will need to run `docker compose up -d --build` to apply these changes.

## What is the pull request?

<!-- Briefly describe the changes introduced by this pull request -->

## Which part of the application is affected by the change?

- [ ] Frontend
- [ ] Backend

## Type of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->