### PR TITLE
Fix: Correct Xray-core download URL and filename in Dockerfile.backend

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -23,13 +23,14 @@ FROM alpine:latest
 
 WORKDIR /app
 RUN mkdir -p /app/bin
-ARG XRAY_VERSION=v1.8.10
+ARG XRAY_VERSION=v1.8.11
 ARG TARGETARCH=amd64
-RUN wget -O /tmp/Xray-linux-${TARGETARCH}.zip https://github.com/XTLS/Xray-core/releases/download/${XRAY_VERSION}/Xray-linux-${TARGETARCH}.zip && \
-    unzip /tmp/Xray-linux-${TARGETARCH}.zip -d /app/bin xray geoip.dat geosite.dat && \
+# Use Xray-linux-64.zip for amd64 architecture as per Xray release naming
+RUN wget -O /tmp/Xray-linux-64.zip https://github.com/XTLS/Xray-core/releases/download/${XRAY_VERSION}/Xray-linux-64.zip && \
+    unzip /tmp/Xray-linux-64.zip -d /app/bin xray geoip.dat geosite.dat && \
     mv /app/bin/xray /app/bin/xray-linux-${TARGETARCH} && \
     chmod +x /app/bin/xray-linux-${TARGETARCH} && \
-    rm /tmp/Xray-linux-${TARGETARCH}.zip
+    rm /tmp/Xray-linux-64.zip
 
 # Copy the binary from the builder stage
 COPY --from=builder /app/x-ui /app/x-ui


### PR DESCRIPTION
The previous attempt to download Xray-core resulted in a 404 error because the specified version/filename combination was incorrect for the amd64 architecture.

This commit updates `Dockerfile.backend` to:
- Use Xray-core version `v1.8.11`.
- Use the filename `Xray-linux-64.zip` for downloading, which is the correct asset name for the linux-amd64 architecture for this version.
- Ensure the extracted binary is still renamed to `xray-linux-${TARGETARCH}` (e.g., `xray-linux-amd64`) to match your application's expectations.

This should resolve the Docker build failure caused by the inability to download the Xray-core binary.

## What is the pull request?

<!-- Briefly describe the changes introduced by this pull request -->

## Which part of the application is affected by the change?

- [ ] Frontend
- [ ] Backend

## Type of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->