### PR TITLE
Hi there, Jules here. I've made some updates to address an issue with…

### DIFF
--- a/3x-ipl.action.conf
+++ b/3x-ipl.action.conf
@@ -1,0 +1,24 @@
+[INCLUDES]
+before = iptables-allports.conf
+
+[Definition]
+actionstart = <iptables> -N f2b-<name>
+              <iptables> -A f2b-<name> -j <returntype>
+              <iptables> -I <chain> -p <protocol> -j f2b-<name>
+
+actionstop = <iptables> -D <chain> -p <protocol> -j f2b-<name>
+             <actionflush>
+             <iptables> -X f2b-<name>
+
+actioncheck = <iptables> -n -L <chain> | grep -q 'f2b-<name>[ 	]'
+
+actionban = <iptables> -I f2b-<name> 1 -s <ip> -j <blocktype>
+            echo "\$(date +"%%Y/%%m/%%d %%H:%%M:%%S")   BAN   [Email] = <F-USER> [IP] = <ip> banned for <bantime> seconds." >> /app/log/3xipl-banned.log
+
+actionunban = <iptables> -D f2b-<name> -s <ip> -j <blocktype>
+              echo "\$(date +"%%Y/%%m/%%d %%H:%%M:%%S")   UNBAN   [Email] = <F-USER> [IP] = <ip> unbanned." >> /app/log/3xipl-banned.log
+
+[Init]
+name = default
+protocol = tcp
+chain = INPUT

--- a/3x-ipl.filter.conf
+++ b/3x-ipl.filter.conf
@@ -1,0 +1,4 @@
+[Definition]
+datepattern = ^%%Y/%%m/%%d %%H:%%M:%%S
+failregex   = \[LIMIT_IP\]\s*Email\s*=\s*<F-USER>.+</F-USER>\s*\|\|\s*SRC\s*=\s*<ADDR>
+ignoreregex =

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -54,6 +54,8 @@ RUN mkdir -p /etc/x-ui && \
 # Let's assume the Go app listens on a port defined by an ENV or config, e.g., 2053
 EXPOSE 2053
 
+COPY 3x-ipl.filter.conf /etc/fail2ban/filter.d/3x-ipl.conf
+COPY 3x-ipl.action.conf /etc/fail2ban/action.d/3x-ipl.conf
 COPY xui_fail2ban.local /etc/fail2ban/jail.local
 # Entrypoint
 ENTRYPOINT ["/app/DockerEntrypoint.sh"]

--- a/xui_fail2ban.local
+++ b/xui_fail2ban.local
@@ -18,7 +18,7 @@ enabled = true
 # If 3x-ui creates /etc/fail2ban/jail.d/3x-ipl.conf, this [3x-ipl] section might be redundant
 # or could conflict. However, disabling sshd is the main goal here.
 port    = http,https,2053 # Example, adjust if your panel port is different
-logpath = %(xui_iplimit_log_path)s # This variable would need to be defined or replaced
+logpath = /app/log/3xipl.log
 # Default log path from xray/process.go -> /app/log/3xipl.log (relative to /app)
 # So, if GetLogFolder() in config returns /app/log, then this should be /app/log/3xipl.log.
 # Let's use a placeholder that 3x-ui might populate or rely on its own jail.d file.
@@ -36,3 +36,6 @@ logpath = %(xui_iplimit_log_path)s # This variable would need to be defined or r
 
 # For now, let's make a simple [3x-ipl] and assume the main app configures it further.
 # The critical part is disabling sshd.
+
+[sshd-ddos]
+enabled = false


### PR DESCRIPTION
… Fail2ban.

Previously, Fail2ban wasn't starting the `3x-ipl` jail correctly because some configuration files were missing.

Here's what I've done:
- I've added a new filter configuration file, `3x-ipl.filter.conf`, which tells Fail2ban how to spot IP limit logs from your 3x-ui application.
- I've also added a new action configuration file, `3x-ipl.action.conf`, which sets up standard banning actions. I've made sure the log path for ban/unban messages in this file is `/app/log/3xipl-banned.log`, to match your application's log path.
- I updated `Dockerfile.backend` so that these two new files are copied to the right places within the Docker image.
- I also made some changes to `xui_fail2ban.local` (which gets copied to `/etc/fail2ban/jail.local`):
    - I've disabled the `[sshd-ddos]` jail to prevent some startup errors, just like the `[sshd]` jail was disabled before.
    - I've updated the `logpath` for the `[3x-ipl]` jail to `/app/log/3xipl.log`, which is where your 3x-ui application should be writing its IP limit logs.

These changes should allow Fail2ban to start up and monitor the `3x-ipl` jail properly, enabling IP banning for your panel. You'll need to rebuild your Docker images to apply these changes.

## What is the pull request?

<!-- Briefly describe the changes introduced by this pull request -->

## Which part of the application is affected by the change?

- [ ] Frontend
- [ ] Backend

## Type of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->