### PR TITLE
Hi there! I've made some comprehensive updates to the backend, fronte…

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -32,6 +32,10 @@ RUN wget -O /tmp/Xray-linux-64.zip https://github.com/XTLS/Xray-core/releases/do
     chmod +x /app/bin/xray-linux-${TARGETARCH} && \
     rm /tmp/Xray-linux-64.zip
 
+RUN mkdir -p /app/log && \
+    touch /app/log/3xipl.log && \
+    touch /app/log/3xipl-banned.log
+
 # Copy the binary from the builder stage
 COPY --from=builder /app/x-ui /app/x-ui
 COPY --from=builder /app/x-ui.sh /app/x-ui.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     build:
       context: ./new-frontend
       dockerfile: Dockerfile
+      args:
+        - NEXT_PUBLIC_API_BASE_URL=http://backend:2053
     container_name: 3x-ui-frontend
     restart: unless-stopped
     ports:

--- a/new-frontend/Dockerfile
+++ b/new-frontend/Dockerfile
@@ -8,6 +8,8 @@ RUN corepack enable
 RUN npm install
 
 COPY . .
+ARG NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
 RUN npm run build
 
 # Stage 2: Production environment


### PR DESCRIPTION
…nd, and Docker setup.

This series of fixes and improvements addresses issues related to Xray-core execution, Fail2ban configuration, frontend API calls, and Docker build processes.

Here's a summary of the key changes:

1.  **Backend (`Dockerfile.backend`, `DockerEntrypoint.sh`):**
    - I enabled CGo and installed SQLite dependencies.
    - I installed Fail2ban.
    - I created the `/app/bin` directory.
    - I've ensured the Xray-core binary (`v1.8.11` for linux-amd64), `geoip.dat`, and `geosite.dat` are downloaded and correctly placed into `/app/bin/` with execute permissions.
    - I copied custom Fail2ban filter (`3x-ipl.filter.conf`) and action (`3x-ipl.action.conf`) files to the appropriate directories in `/etc/fail2ban/`.
    - I copied a custom `jail.local` (as `xui_fail2ban.local`) to `/etc/fail2ban/`. This configuration:
        - Disables `sshd` and `sshd-ddos` jails.
        - Sets `logpath` for the `[3x-ipl]` jail to `/app/log/3xipl.log`.
    - I created the `/app/log` directory and the files `3xipl.log` and `3xipl-banned.log` to ensure they exist for Fail2ban.
    - The `DockerEntrypoint.sh` script now checks for `fail2ban-client` before execution.

2.  **Frontend (`new-frontend/Dockerfile`, `docker-compose.yml`):**
    - I modified `new-frontend/Dockerfile` to include `ARG NEXT_PUBLIC_API_BASE_URL` and `ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL` before the `npm run build` command.
    - I updated `docker-compose.yml` for the `frontend` service to pass `NEXT_PUBLIC_API_BASE_URL` as a build argument via the `args` section. This ensures the API base URL is correctly inlined during the Next.js build, fixing issues with API calls that were previously going to the frontend's own host and port.

3.  **Docker Compose (`docker-compose.yml`):**
    - I removed the obsolete `version: '3.8'` line.

4.  **New Configuration Files (root of repo):**
    - `xui_fail2ban.local`: Custom jail settings for Fail2ban.
    - `3x-ipl.filter.conf`: Filter definition for 3x-ui IP limiting.
    - `3x-ipl.action.conf`: Action definition for 3x-ui IP limiting.

These changes aim to provide a stable build and runtime environment, resolve frontend API call issues, and correctly configure Fail2ban. You should pull these changes, rebuild your Docker images, and test thoroughly.

## What is the pull request?

<!-- Briefly describe the changes introduced by this pull request -->

## Which part of the application is affected by the change?

- [ ] Frontend
- [ ] Backend

## Type of Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Other

## Screenshots

<!-- Add screenshots to illustrate the changes -->
<!-- Remove this section if it is not applicable. -->